### PR TITLE
Fix faulty error reporting for write-protected mmap

### DIFF
--- a/threads.pd
+++ b/threads.pd
@@ -108,7 +108,7 @@ sub share_pdls {
 				croak("$to_croak you do not have permissions to read the "
 					. "associated header file") unless -r "$to_store.hdr";
 				croak("$to_croak you do not have write permissions for that "
-					. "file") if -w $to_store;
+					. "file") unless -w $to_store;
 				# Default: the file does not exist
 				croak("$to_croak the file does not exist");
 			}


### PR DESCRIPTION
Fixes incorrect logic checking if an mmapped file is writeable.

Obviously I never wrote tests for the error messaging, so this pull request should include another commit that adds tests.