### PR TITLE
GHA: Update CI to use `os: macos-latest`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
             os: windows-latest
           - perl-version: '5.30'
             perl-threaded: true
-            os: macos-11
+            os: macos-latest
           - perl-version: '5.30'
             perl-threaded: false
             os: ubuntu-latest


### PR DESCRIPTION
Connects to <https://github.com/PDLPorters/devops/issues/46>.
